### PR TITLE
HYDRAN-2465 TenantAwareAutoDeployment & Authenticate ExternalTask calls

### DIFF
--- a/src/integration-test/resources/Wiremock/mappings/api-gateway-token.json
+++ b/src/integration-test/resources/Wiremock/mappings/api-gateway-token.json
@@ -1,0 +1,16 @@
+{
+	"metadata": {
+		"comment": "Boot-time stub, unlike the programmatic mockApiGatewayToken() used elsewhere. WireMock auto-loads files under mappings/ when the server starts - before the Spring context initializes. When process-engine.type=operaton, TenantAwareAutoDeployment deploys via OperatonClient in @PostConstruct, which goes through the OAuth2 interceptor and needs a token during context initialization. A programmatic stub registered in the test lifecycle (@BeforeEach/@Test) is registered too late for that, so the token endpoint must be stubbed here instead."
+	},
+	"request": {
+		"method": "POST",
+		"url": "/api-gateway/token"
+	},
+	"response": {
+		"status": 200,
+		"headers": {
+			"Content-Type": "application/json"
+		},
+		"bodyFileName": "common/responses/api-gateway-retrieve-token.json"
+	}
+}

--- a/src/main/java/se/sundsvall/parkingpermit/integration/camunda/deployment/TenantAwareAutoDeployment.java
+++ b/src/main/java/se/sundsvall/parkingpermit/integration/camunda/deployment/TenantAwareAutoDeployment.java
@@ -12,8 +12,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
-import se.sundsvall.parkingpermit.integration.camunda.CamundaClient;
 import se.sundsvall.parkingpermit.integration.camunda.deployment.DeploymentProperties.ProcessArchive;
+import se.sundsvall.parkingpermit.integration.engine.EngineClient;
 
 import static java.util.Collections.emptyList;
 import static java.util.Objects.isNull;
@@ -30,14 +30,14 @@ public class TenantAwareAutoDeployment {
 	private static final String FILETYPE_FORM = "form";
 	private static final Resource[] NO_RESOURCES = {};
 
-	private final CamundaClient camundaClient;
+	private final EngineClient engineClient;
 
 	private final DeploymentProperties deployments;
 
 	private final ResourcePatternResolver patternResolver;
 
-	TenantAwareAutoDeployment(CamundaClient camundaClient, DeploymentProperties deployments, ResourcePatternResolver patternResolver) {
-		this.camundaClient = camundaClient;
+	TenantAwareAutoDeployment(EngineClient engineClient, DeploymentProperties deployments, ResourcePatternResolver patternResolver) {
+		this.engineClient = engineClient;
 		this.deployments = deployments;
 		this.patternResolver = patternResolver;
 	}
@@ -46,7 +46,7 @@ public class TenantAwareAutoDeployment {
 	private String applicationName;
 
 	@PostConstruct
-	public void deployCamundaResources() {
+	public void deployProcessResources() {
 		if (isNull(deployments) || !deployments.isAutoDeployEnabled()) {
 			return;
 		}
@@ -75,7 +75,7 @@ public class TenantAwareAutoDeployment {
 					IOUtils.copy(camundaResource.getInputStream(), out);
 				}
 
-				camundaClient.deploy(
+				engineClient.deploy(
 					processArchive.tenant(), // tenantId
 					camundaResource.getFilename(),
 					true, // changedOnly

--- a/src/main/java/se/sundsvall/parkingpermit/integration/engine/CamundaEngineClient.java
+++ b/src/main/java/se/sundsvall/parkingpermit/integration/engine/CamundaEngineClient.java
@@ -1,6 +1,8 @@
 package se.sundsvall.parkingpermit.integration.engine;
 
 import generated.se.sundsvall.camunda.VariableValueDto;
+import java.io.File;
+import java.time.OffsetDateTime;
 import se.sundsvall.parkingpermit.integration.camunda.CamundaClient;
 
 class CamundaEngineClient implements EngineClient {
@@ -14,5 +16,10 @@ class CamundaEngineClient implements EngineClient {
 	@Override
 	public void setProcessInstanceVariable(final String processInstanceId, final String variableName, final VariableValueDto value) {
 		camundaClient.setProcessInstanceVariable(processInstanceId, variableName, value);
+	}
+
+	@Override
+	public void deploy(final String tenantId, final String deploymentSource, final Boolean deployChangedOnly, final Boolean enableDuplicateFiltering, final String deploymentName, final OffsetDateTime deploymentActivationTime, final File data) {
+		camundaClient.deploy(tenantId, deploymentSource, deployChangedOnly, enableDuplicateFiltering, deploymentName, deploymentActivationTime, data);
 	}
 }

--- a/src/main/java/se/sundsvall/parkingpermit/integration/engine/EngineClient.java
+++ b/src/main/java/se/sundsvall/parkingpermit/integration/engine/EngineClient.java
@@ -1,15 +1,19 @@
 package se.sundsvall.parkingpermit.integration.engine;
 
 import generated.se.sundsvall.camunda.VariableValueDto;
+import java.io.File;
+import java.time.OffsetDateTime;
 
 /**
- * Abstraction over the process engine used by the task workers. The active implementation is selected at startup via
+ * Abstraction over the process engine targeted by this instance. The active implementation is selected at startup via
  * the
- * {@code process-engine.type} property ({@code camunda} or {@code operaton}), so the same worker code targets whichever
- * engine the instance is polling. The canonical variable type is the Camunda {@link VariableValueDto}; the Operaton
- * implementation converts it to its own DTO.
+ * {@code process-engine.type} property ({@code camunda} or {@code operaton}), so both the task workers and the startup
+ * auto-deployment target whichever engine the instance is polling. The canonical variable type is the Camunda
+ * {@link VariableValueDto}; the Operaton implementation converts it to its own DTO.
  */
 public interface EngineClient {
 
 	void setProcessInstanceVariable(String processInstanceId, String variableName, VariableValueDto value);
+
+	void deploy(String tenantId, String deploymentSource, Boolean deployChangedOnly, Boolean enableDuplicateFiltering, String deploymentName, OffsetDateTime deploymentActivationTime, File data);
 }

--- a/src/main/java/se/sundsvall/parkingpermit/integration/engine/OperatonEngineClient.java
+++ b/src/main/java/se/sundsvall/parkingpermit/integration/engine/OperatonEngineClient.java
@@ -1,6 +1,8 @@
 package se.sundsvall.parkingpermit.integration.engine;
 
 import generated.se.sundsvall.camunda.VariableValueDto;
+import java.io.File;
+import java.time.OffsetDateTime;
 import se.sundsvall.parkingpermit.integration.operaton.OperatonClient;
 
 class OperatonEngineClient implements EngineClient {
@@ -14,6 +16,11 @@ class OperatonEngineClient implements EngineClient {
 	@Override
 	public void setProcessInstanceVariable(final String processInstanceId, final String variableName, final VariableValueDto value) {
 		operatonClient.setProcessInstanceVariable(processInstanceId, variableName, toOperatonVariableValueDto(value));
+	}
+
+	@Override
+	public void deploy(final String tenantId, final String deploymentSource, final Boolean deployChangedOnly, final Boolean enableDuplicateFiltering, final String deploymentName, final OffsetDateTime deploymentActivationTime, final File data) {
+		operatonClient.deploy(tenantId, deploymentSource, deployChangedOnly, enableDuplicateFiltering, deploymentName, deploymentActivationTime, data);
 	}
 
 	private static generated.se.sundsvall.operaton.VariableValueDto toOperatonVariableValueDto(final VariableValueDto value) {

--- a/src/main/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskAuthInterceptor.java
+++ b/src/main/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskAuthInterceptor.java
@@ -1,0 +1,37 @@
+package se.sundsvall.parkingpermit.integration.operaton.configuration;
+
+import org.camunda.bpm.client.interceptor.ClientRequestContext;
+import org.camunda.bpm.client.interceptor.ClientRequestInterceptor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+
+import static java.util.Objects.nonNull;
+import static se.sundsvall.parkingpermit.integration.operaton.configuration.OperatonConfiguration.CLIENT_ID;
+
+/**
+ * Adds a WSO2 client-credentials bearer token to every external task request (fetchAndLock/complete/handleFailure) so
+ * the Operaton instance can poll api-service-operaton, which sits behind the OAuth2-secured gateway. Only registered
+ * when this instance targets Operaton (see {@link OperatonExternalTaskClientConfiguration}); the Camunda instance polls
+ * its engine directly without a token.
+ */
+class OperatonExternalTaskAuthInterceptor implements ClientRequestInterceptor {
+
+	private static final String PRINCIPAL = "operaton-external-task-client";
+
+	private final OAuth2AuthorizedClientManager authorizedClientManager;
+
+	OperatonExternalTaskAuthInterceptor(final OAuth2AuthorizedClientManager authorizedClientManager) {
+		this.authorizedClientManager = authorizedClientManager;
+	}
+
+	@Override
+	public void intercept(final ClientRequestContext requestContext) {
+		final var authorizedClient = authorizedClientManager.authorize(
+			OAuth2AuthorizeRequest.withClientRegistrationId(CLIENT_ID).principal(PRINCIPAL).build());
+
+		if (nonNull(authorizedClient)) {
+			requestContext.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + authorizedClient.getAccessToken().getTokenValue());
+		}
+	}
+}

--- a/src/main/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskClientConfiguration.java
+++ b/src/main/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskClientConfiguration.java
@@ -1,0 +1,30 @@
+package se.sundsvall.parkingpermit.integration.operaton.configuration;
+
+import org.camunda.bpm.client.interceptor.ClientRequestInterceptor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+
+/**
+ * Wires WSO2 OAuth2 authentication onto the external task client, but only when this instance targets Operaton
+ * ({@code process-engine.type=operaton}). The camunda-bpm external task client auto-registers every
+ * {@link ClientRequestInterceptor} bean in the context, so a Camunda instance - where this bean is absent - keeps
+ * polling its engine without a token. The token is obtained for the same {@code operaton} client registration that the
+ * Feign {@code OperatonClient} uses.
+ */
+@Configuration
+@ConditionalOnProperty(name = "process-engine.type", havingValue = "operaton")
+public class OperatonExternalTaskClientConfiguration {
+
+	@Bean
+	ClientRequestInterceptor operatonExternalTaskAuthInterceptor(final ClientRegistrationRepository clientRegistrationRepository, final OAuth2AuthorizedClientService authorizedClientService) {
+		final var authorizedClientManager = new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
+		authorizedClientManager.setAuthorizedClientProvider(OAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build());
+
+		return new OperatonExternalTaskAuthInterceptor(authorizedClientManager);
+	}
+}

--- a/src/test/java/se/sundsvall/parkingpermit/integration/camunda/deployment/TenantAwareAutoDeploymentTest.java
+++ b/src/test/java/se/sundsvall/parkingpermit/integration/camunda/deployment/TenantAwareAutoDeploymentTest.java
@@ -14,8 +14,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.core.io.support.ResourcePatternResolver;
-import se.sundsvall.parkingpermit.integration.camunda.CamundaClient;
 import se.sundsvall.parkingpermit.integration.camunda.deployment.DeploymentProperties.ProcessArchive;
+import se.sundsvall.parkingpermit.integration.engine.EngineClient;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -24,6 +24,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -41,7 +42,7 @@ class TenantAwareAutoDeploymentTest {
 	private static final String FILETYPE_FORM = "form";
 
 	@Mock
-	private CamundaClient deploymentApiMock;
+	private EngineClient deploymentApiMock;
 
 	@Mock
 	private DeploymentProperties deploymentPropertiesMock;
@@ -66,7 +67,7 @@ class TenantAwareAutoDeploymentTest {
 
 		when(deploymentPropertiesMock.isAutoDeployEnabled()).thenReturn(false);
 
-		tenantAwareAutoDeployment.deployCamundaResources();
+		tenantAwareAutoDeployment.deployProcessResources();
 
 		verify(deploymentPropertiesMock, atLeastOnce()).isAutoDeployEnabled();
 		verifyNoInteractions(deploymentApiMock, resourcePatternResolverMock);
@@ -76,7 +77,7 @@ class TenantAwareAutoDeploymentTest {
 	void autoDeployEnabledButNoDefinedProcesses() {
 		when(deploymentPropertiesMock.isAutoDeployEnabled()).thenReturn(true);
 
-		tenantAwareAutoDeployment.deployCamundaResources();
+		tenantAwareAutoDeployment.deployProcessResources();
 
 		verify(deploymentPropertiesMock, atLeastOnce()).isAutoDeployEnabled();
 		verifyNoInteractions(deploymentApiMock, resourcePatternResolverMock);
@@ -90,7 +91,7 @@ class TenantAwareAutoDeploymentTest {
 		when(deploymentPropertiesMock.getProcesses()).thenReturn(List.of(processArchiveMock));
 		when(processArchiveMock.name()).thenReturn(name);
 
-		tenantAwareAutoDeployment.deployCamundaResources();
+		tenantAwareAutoDeployment.deployProcessResources();
 
 		verify(deploymentPropertiesMock, atLeastOnce()).isAutoDeployEnabled();
 		verify(resourcePatternResolverMock).getResources(DEFAULT_PATTERN_PREFIX + FILETYPE_BPMN);
@@ -105,7 +106,7 @@ class TenantAwareAutoDeploymentTest {
 		when(deploymentPropertiesMock.isAutoDeployEnabled()).thenReturn(true);
 		when(deploymentPropertiesMock.getProcesses()).thenReturn(List.of(processArchiveMock));
 
-		final var exception = assertThrows(IllegalArgumentException.class, () -> tenantAwareAutoDeployment.deployCamundaResources());
+		final var exception = assertThrows(IllegalArgumentException.class, () -> tenantAwareAutoDeployment.deployProcessResources());
 
 		verifyNoInteractions(deploymentApiMock);
 		assertThat(exception.getMessage()).isEqualTo("Processname must be set");
@@ -125,7 +126,7 @@ class TenantAwareAutoDeploymentTest {
 		when(processArchiveMock.dmnResourcePattern()).thenReturn(custom_pattern_dmn);
 		when(processArchiveMock.formResourcePattern()).thenReturn(custom_pattern_form);
 
-		tenantAwareAutoDeployment.deployCamundaResources();
+		tenantAwareAutoDeployment.deployProcessResources();
 
 		verify(deploymentPropertiesMock, atLeastOnce()).isAutoDeployEnabled();
 		verify(resourcePatternResolverMock).getResources(custom_pattern_bpmn);
@@ -152,7 +153,7 @@ class TenantAwareAutoDeploymentTest {
 		when(resourceMock.getFilename()).thenReturn(PROCESSMODEL_FILE);
 		when(resourceMock.getInputStream()).thenReturn(processFile.getInputStream());
 
-		tenantAwareAutoDeployment.deployCamundaResources();
+		tenantAwareAutoDeployment.deployProcessResources();
 
 		verify(deploymentPropertiesMock, atLeastOnce()).isAutoDeployEnabled();
 		verify(resourcePatternResolverMock).getResources(DEFAULT_PATTERN_PREFIX + FILETYPE_BPMN);
@@ -171,7 +172,7 @@ class TenantAwareAutoDeploymentTest {
 		when(deploymentPropertiesMock.getProcesses()).thenReturn(List.of(processArchiveMock));
 		when(resourcePatternResolverMock.getResources(any())).thenThrow(originException);
 
-		final var exception = assertThrows(DeploymentException.class, () -> tenantAwareAutoDeployment.deployCamundaResources());
+		final var exception = assertThrows(DeploymentException.class, () -> tenantAwareAutoDeployment.deployProcessResources());
 
 		verify(resourcePatternResolverMock).getResources(DEFAULT_PATTERN_PREFIX + FILETYPE_BPMN);
 		verifyNoMoreInteractions(resourcePatternResolverMock);
@@ -187,14 +188,14 @@ class TenantAwareAutoDeploymentTest {
 		when(deploymentPropertiesMock.isAutoDeployEnabled()).thenReturn(true);
 		when(deploymentPropertiesMock.getProcesses()).thenReturn(List.of(processArchiveMock));
 		when(processArchiveMock.name()).thenReturn(name);
-		when(deploymentApiMock.deploy(any(), any(), anyBoolean(), anyBoolean(), any(), any(), any())).thenThrow(originException);
+		doThrow(originException).when(deploymentApiMock).deploy(any(), any(), anyBoolean(), anyBoolean(), any(), any(), any());
 		when(resourcePatternResolverMock.getResources(DEFAULT_PATTERN_PREFIX + FILETYPE_BPMN)).thenReturn(new Resource[] {
 			resourceMock
 		});
 		when(resourceMock.getFilename()).thenReturn(PROCESSMODEL_FILE);
 		when(resourceMock.getInputStream()).thenReturn(new ClassPathResource(PROCESSMODEL_PATH + PROCESSMODEL_FILE).getInputStream());
 
-		final var exception = assertThrows(DeploymentException.class, () -> tenantAwareAutoDeployment.deployCamundaResources());
+		final var exception = assertThrows(DeploymentException.class, () -> tenantAwareAutoDeployment.deployProcessResources());
 
 		verify(resourcePatternResolverMock).getResources(DEFAULT_PATTERN_PREFIX + FILETYPE_BPMN);
 		verify(deploymentApiMock).deploy(any(), any(), anyBoolean(), anyBoolean(), any(), any(), any());

--- a/src/test/java/se/sundsvall/parkingpermit/integration/engine/CamundaEngineClientTest.java
+++ b/src/test/java/se/sundsvall/parkingpermit/integration/engine/CamundaEngineClientTest.java
@@ -1,6 +1,8 @@
 package se.sundsvall.parkingpermit.integration.engine;
 
 import generated.se.sundsvall.camunda.VariableValueDto;
+import java.io.File;
+import java.time.OffsetDateTime;
 import org.camunda.bpm.engine.variable.type.ValueType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,6 +26,17 @@ class CamundaEngineClientTest {
 		new CamundaEngineClient(camundaClientMock).setProcessInstanceVariable("processInstanceId", "variableName", value);
 
 		verify(camundaClientMock).setProcessInstanceVariable("processInstanceId", "variableName", value);
+		verifyNoMoreInteractions(camundaClientMock);
+	}
+
+	@Test
+	void deployDelegatesToCamundaClient() {
+		final var data = new File("process.bpmn");
+		final var activationTime = OffsetDateTime.now();
+
+		new CamundaEngineClient(camundaClientMock).deploy("tenantId", "deploymentSource", true, true, "deploymentName", activationTime, data);
+
+		verify(camundaClientMock).deploy("tenantId", "deploymentSource", true, true, "deploymentName", activationTime, data);
 		verifyNoMoreInteractions(camundaClientMock);
 	}
 }

--- a/src/test/java/se/sundsvall/parkingpermit/integration/engine/CamundaEngineClientTest.java
+++ b/src/test/java/se/sundsvall/parkingpermit/integration/engine/CamundaEngineClientTest.java
@@ -32,7 +32,7 @@ class CamundaEngineClientTest {
 	@Test
 	void deployDelegatesToCamundaClient() {
 		final var data = new File("process.bpmn");
-		final var activationTime = OffsetDateTime.now();
+		final var activationTime = OffsetDateTime.parse("2026-01-01T00:00:00Z");
 
 		new CamundaEngineClient(camundaClientMock).deploy("tenantId", "deploymentSource", true, true, "deploymentName", activationTime, data);
 

--- a/src/test/java/se/sundsvall/parkingpermit/integration/engine/OperatonEngineClientTest.java
+++ b/src/test/java/se/sundsvall/parkingpermit/integration/engine/OperatonEngineClientTest.java
@@ -44,7 +44,7 @@ class OperatonEngineClientTest {
 	@Test
 	void deployDelegatesToOperatonClient() {
 		final var data = new File("process.bpmn");
-		final var activationTime = OffsetDateTime.now();
+		final var activationTime = OffsetDateTime.parse("2026-01-01T00:00:00Z");
 
 		new OperatonEngineClient(operatonClientMock).deploy("tenantId", "deploymentSource", true, true, "deploymentName", activationTime, data);
 

--- a/src/test/java/se/sundsvall/parkingpermit/integration/engine/OperatonEngineClientTest.java
+++ b/src/test/java/se/sundsvall/parkingpermit/integration/engine/OperatonEngineClientTest.java
@@ -1,6 +1,8 @@
 package se.sundsvall.parkingpermit.integration.engine;
 
 import generated.se.sundsvall.camunda.VariableValueDto;
+import java.io.File;
+import java.time.OffsetDateTime;
 import java.util.Map;
 import org.camunda.bpm.engine.variable.type.ValueType;
 import org.junit.jupiter.api.Test;
@@ -37,5 +39,16 @@ class OperatonEngineClientTest {
 		assertThat(valueCaptor.getValue().getType()).isEqualTo(ValueType.BOOLEAN.getName());
 		assertThat(valueCaptor.getValue().getValue()).isEqualTo(false);
 		assertThat(valueCaptor.getValue().getValueInfo()).isEqualTo(valueInfo);
+	}
+
+	@Test
+	void deployDelegatesToOperatonClient() {
+		final var data = new File("process.bpmn");
+		final var activationTime = OffsetDateTime.now();
+
+		new OperatonEngineClient(operatonClientMock).deploy("tenantId", "deploymentSource", true, true, "deploymentName", activationTime, data);
+
+		verify(operatonClientMock).deploy("tenantId", "deploymentSource", true, true, "deploymentName", activationTime, data);
+		verifyNoMoreInteractions(operatonClientMock);
 	}
 }

--- a/src/test/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskAuthInterceptorTest.java
+++ b/src/test/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskAuthInterceptorTest.java
@@ -28,7 +28,8 @@ class OperatonExternalTaskAuthInterceptorTest {
 
 	@Test
 	void addsBearerTokenHeader() {
-		final var accessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, "the-token", Instant.now(), Instant.now().plusSeconds(60));
+		final var issuedAt = Instant.parse("2026-01-01T00:00:00Z");
+		final var accessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, "the-token", issuedAt, issuedAt.plusSeconds(60));
 		final var authorizedClient = mock(OAuth2AuthorizedClient.class);
 		when(authorizedClient.getAccessToken()).thenReturn(accessToken);
 		when(authorizedClientManagerMock.authorize(any(OAuth2AuthorizeRequest.class))).thenReturn(authorizedClient);

--- a/src/test/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskAuthInterceptorTest.java
+++ b/src/test/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskAuthInterceptorTest.java
@@ -1,0 +1,49 @@
+package se.sundsvall.parkingpermit.integration.operaton.configuration;
+
+import java.time.Instant;
+import org.camunda.bpm.client.interceptor.ClientRequestContext;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class OperatonExternalTaskAuthInterceptorTest {
+
+	@Mock
+	private OAuth2AuthorizedClientManager authorizedClientManagerMock;
+
+	@Mock
+	private ClientRequestContext requestContextMock;
+
+	@Test
+	void addsBearerTokenHeader() {
+		final var accessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, "the-token", Instant.now(), Instant.now().plusSeconds(60));
+		final var authorizedClient = mock(OAuth2AuthorizedClient.class);
+		when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+		when(authorizedClientManagerMock.authorize(any(OAuth2AuthorizeRequest.class))).thenReturn(authorizedClient);
+
+		new OperatonExternalTaskAuthInterceptor(authorizedClientManagerMock).intercept(requestContextMock);
+
+		verify(requestContextMock).addHeader("Authorization", "Bearer the-token");
+	}
+
+	@Test
+	void doesNotAddHeaderWhenNotAuthorized() {
+		when(authorizedClientManagerMock.authorize(any(OAuth2AuthorizeRequest.class))).thenReturn(null);
+
+		new OperatonExternalTaskAuthInterceptor(authorizedClientManagerMock).intercept(requestContextMock);
+
+		verifyNoInteractions(requestContextMock);
+	}
+}

--- a/src/test/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskClientConfigurationTest.java
+++ b/src/test/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskClientConfigurationTest.java
@@ -1,0 +1,35 @@
+package se.sundsvall.parkingpermit.integration.operaton.configuration;
+
+import org.camunda.bpm.client.interceptor.ClientRequestInterceptor;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+class OperatonExternalTaskClientConfigurationTest {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withUserConfiguration(OperatonExternalTaskClientConfiguration.class)
+		.withBean(ClientRegistrationRepository.class, () -> mock(ClientRegistrationRepository.class))
+		.withBean(OAuth2AuthorizedClientService.class, () -> mock(OAuth2AuthorizedClientService.class));
+
+	@Test
+	void interceptorRegisteredWhenEngineIsOperaton() {
+		contextRunner.withPropertyValues("process-engine.type=operaton")
+			.run(context -> assertThat(context).hasSingleBean(ClientRequestInterceptor.class));
+	}
+
+	@Test
+	void interceptorNotRegisteredWhenEngineIsCamunda() {
+		contextRunner.withPropertyValues("process-engine.type=camunda")
+			.run(context -> assertThat(context).doesNotHaveBean(ClientRequestInterceptor.class));
+	}
+
+	@Test
+	void interceptorNotRegisteredByDefault() {
+		contextRunner.run(context -> assertThat(context).doesNotHaveBean(ClientRequestInterceptor.class));
+	}
+}


### PR DESCRIPTION
* Make TenantAwareAutoDeployment deploy via EngineClient so each instance deploys to its configured engine (Camunda/Operaton)
* Add conditional ClientRequestInterceptor so the Operaton instance bearer-authenticates external-task calls

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix
- [x] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
