### PR TITLE
HYDRAN-2564 Force fresh WSO2 token 

### DIFF
--- a/src/main/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskAuthInterceptor.java
+++ b/src/main/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskAuthInterceptor.java
@@ -5,8 +5,9 @@ import org.camunda.bpm.client.interceptor.ClientRequestInterceptor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 
-import static java.util.Objects.nonNull;
+import static java.util.Objects.isNull;
 import static se.sundsvall.parkingpermit.integration.operaton.configuration.OperatonConfiguration.CLIENT_ID;
 
 /**
@@ -20,18 +21,27 @@ class OperatonExternalTaskAuthInterceptor implements ClientRequestInterceptor {
 	private static final String PRINCIPAL = "operaton-external-task-client";
 
 	private final OAuth2AuthorizedClientManager authorizedClientManager;
+	private final OAuth2AuthorizedClientService authorizedClientService;
 
-	OperatonExternalTaskAuthInterceptor(final OAuth2AuthorizedClientManager authorizedClientManager) {
+	OperatonExternalTaskAuthInterceptor(final OAuth2AuthorizedClientManager authorizedClientManager, final OAuth2AuthorizedClientService authorizedClientService) {
 		this.authorizedClientManager = authorizedClientManager;
+		this.authorizedClientService = authorizedClientService;
 	}
 
 	@Override
 	public void intercept(final ClientRequestContext requestContext) {
+		// Evict any cached token before authorizing so every poll forces a freshly issued token. The manager only renews
+		// near the nominal expiresAt, but WSO2 may invalidate a token server-side early (gateway restart, revocation,
+		// clock drift); since this interceptor never sees the response it cannot detect a 401 and evict afterwards.
+		authorizedClientService.removeAuthorizedClient(CLIENT_ID, PRINCIPAL);
+
 		final var authorizedClient = authorizedClientManager.authorize(
 			OAuth2AuthorizeRequest.withClientRegistrationId(CLIENT_ID).principal(PRINCIPAL).build());
 
-		if (nonNull(authorizedClient)) {
-			requestContext.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + authorizedClient.getAccessToken().getTokenValue());
+		if (isNull(authorizedClient)) {
+			throw new IllegalStateException("Could not obtain a WSO2 access token for client registration '" + CLIENT_ID + "'; check the OAuth2 client-credentials configuration");
 		}
+
+		requestContext.addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + authorizedClient.getAccessToken().getTokenValue());
 	}
 }

--- a/src/main/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskClientConfiguration.java
+++ b/src/main/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskClientConfiguration.java
@@ -25,6 +25,6 @@ public class OperatonExternalTaskClientConfiguration {
 		final var authorizedClientManager = new AuthorizedClientServiceOAuth2AuthorizedClientManager(clientRegistrationRepository, authorizedClientService);
 		authorizedClientManager.setAuthorizedClientProvider(OAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build());
 
-		return new OperatonExternalTaskAuthInterceptor(authorizedClientManager);
+		return new OperatonExternalTaskAuthInterceptor(authorizedClientManager, authorizedClientService);
 	}
 }

--- a/src/test/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskAuthInterceptorTest.java
+++ b/src/test/java/se/sundsvall/parkingpermit/integration/operaton/configuration/OperatonExternalTaskAuthInterceptorTest.java
@@ -9,19 +9,28 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static se.sundsvall.parkingpermit.integration.operaton.configuration.OperatonConfiguration.CLIENT_ID;
 
 @ExtendWith(MockitoExtension.class)
 class OperatonExternalTaskAuthInterceptorTest {
 
+	private static final String PRINCIPAL = "operaton-external-task-client";
+
 	@Mock
 	private OAuth2AuthorizedClientManager authorizedClientManagerMock;
+
+	@Mock
+	private OAuth2AuthorizedClientService authorizedClientServiceMock;
 
 	@Mock
 	private ClientRequestContext requestContextMock;
@@ -34,16 +43,39 @@ class OperatonExternalTaskAuthInterceptorTest {
 		when(authorizedClient.getAccessToken()).thenReturn(accessToken);
 		when(authorizedClientManagerMock.authorize(any(OAuth2AuthorizeRequest.class))).thenReturn(authorizedClient);
 
-		new OperatonExternalTaskAuthInterceptor(authorizedClientManagerMock).intercept(requestContextMock);
+		new OperatonExternalTaskAuthInterceptor(authorizedClientManagerMock, authorizedClientServiceMock).intercept(requestContextMock);
 
 		verify(requestContextMock).addHeader("Authorization", "Bearer the-token");
 	}
 
 	@Test
-	void doesNotAddHeaderWhenNotAuthorized() {
+	void evictsCachedTokenBeforeEachAuthorize() {
+		final var issuedAt = Instant.parse("2026-01-01T00:00:00Z");
+		final var accessToken = new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, "the-token", issuedAt, issuedAt.plusSeconds(60));
+		final var authorizedClient = mock(OAuth2AuthorizedClient.class);
+		when(authorizedClient.getAccessToken()).thenReturn(accessToken);
+		when(authorizedClientManagerMock.authorize(any(OAuth2AuthorizeRequest.class))).thenReturn(authorizedClient);
+
+		final var interceptor = new OperatonExternalTaskAuthInterceptor(authorizedClientManagerMock, authorizedClientServiceMock);
+		interceptor.intercept(requestContextMock);
+		interceptor.intercept(requestContextMock);
+
+		final var inOrder = inOrder(authorizedClientServiceMock, authorizedClientManagerMock);
+		inOrder.verify(authorizedClientServiceMock).removeAuthorizedClient(CLIENT_ID, PRINCIPAL);
+		inOrder.verify(authorizedClientManagerMock).authorize(any(OAuth2AuthorizeRequest.class));
+		inOrder.verify(authorizedClientServiceMock).removeAuthorizedClient(CLIENT_ID, PRINCIPAL);
+		inOrder.verify(authorizedClientManagerMock).authorize(any(OAuth2AuthorizeRequest.class));
+	}
+
+	@Test
+	void throwsWhenNoTokenCanBeObtained() {
 		when(authorizedClientManagerMock.authorize(any(OAuth2AuthorizeRequest.class))).thenReturn(null);
 
-		new OperatonExternalTaskAuthInterceptor(authorizedClientManagerMock).intercept(requestContextMock);
+		final var interceptor = new OperatonExternalTaskAuthInterceptor(authorizedClientManagerMock, authorizedClientServiceMock);
+
+		assertThatThrownBy(() -> interceptor.intercept(requestContextMock))
+			.isInstanceOf(IllegalStateException.class)
+			.hasMessageContaining(CLIENT_ID);
 
 		verifyNoInteractions(requestContextMock);
 	}


### PR DESCRIPTION
* Harden Operaton external-task auth against stale/invalid tokens

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix
- [ ] New feature
- [ ] Removed feature
- [ ] Code style update (formatting etc.)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Content/Data

## Does this PR introduce a breaking change?
- [ ] Yes (I have stepped the version number accordingly)
- [x] No
      
## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly (if applicable).
- [x] I have added/updated tests to cover my changes (if applicable).
